### PR TITLE
Fix missing track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,12 @@ ENV/
 env.bak/
 venv.bak/
 
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
+++ b/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
@@ -94,10 +94,11 @@ class BaseYouTubeMusicDL(object):
             download = True,
         )
 
+        any_title = info.get('track', info.get('title'))
         metadata = utils.filter \
         (
             {
-                'title':       info.get('track', info.get('title')),
+                'title':       any_title,
                 'artist':      info.get('artist'),
                 'album':       info.get('album'),
                 'albumartist': info.get('artist'),
@@ -107,13 +108,14 @@ class BaseYouTubeMusicDL(object):
                 **metadata,
             }
         )
+        info.setdefault('track', any_title)
 
         file_path_src = self._get_file_path \
         (
             info,
             file_name_format % \
             {
-                'title': metadata.get('title'),
+                'title': info.get('title'),
                 'ext': to_ext,
             },
             directory,

--- a/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
+++ b/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
@@ -97,7 +97,7 @@ class BaseYouTubeMusicDL(object):
         metadata = utils.filter \
         (
             {
-                'title':       info.get('track'),
+                'title':       info.get('track', info.get('title')),
                 'artist':      info.get('artist'),
                 'album':       info.get('album'),
                 'albumartist': info.get('artist'),
@@ -113,7 +113,7 @@ class BaseYouTubeMusicDL(object):
             info,
             file_name_format % \
             {
-                'title': info.get('title'),
+                'title': metadata.get('title'),
                 'ext': to_ext,
             },
             directory,


### PR DESCRIPTION
Fix a (rare?) missing field error that I encountered. 

For example, I tried `YouTubeMusicDL.download_album` operation with link: 
https://music.youtube.com/playlist?list=OLAK5uy_nmme7IwmAAjP8_ISwrCD-mwfwbY_DolPo

For the first 11 tracks, everything works as normal.
When it reached the 12th track (`"name": "Memory Fiction", "id": "swAvmmkBCzs"`), `KeyError` is raised because of missing `track`. 
It seems that YTDL API doesn't always provide that field (probably based on the video metadata?).


