### PR TITLE
replace possible illegal characters forming the downloaded file name

### DIFF
--- a/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
+++ b/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
@@ -110,12 +110,16 @@ class BaseYouTubeMusicDL(object):
         )
         info.setdefault('track', any_title)
 
+        sanitized_name = info['title']
+        illegal_chars = ['\\', '/', ':', '*', '?', '<', '>', '|', '"']
+        for char in illegal_chars:
+            sanitized_name = sanitized_name.replace(char, '_')
         file_path_src = self._get_file_path \
         (
             info,
             file_name_format % \
             {
-                'title': info.get('title'),
+                'title': sanitized_name,
                 'ext': to_ext,
             },
             directory,
@@ -125,7 +129,7 @@ class BaseYouTubeMusicDL(object):
         (
             file_name_format % \
             {
-                'title': info.get('title'),
+                'title': sanitized_name,
                 'ext':   to_ext,
             }
         )


### PR DESCRIPTION
In the off chance that the `track` detail was missing and that the info defaulted to using the `title` while `metadata` did not provide a clean version of it, the resulting info title could be any character (eg: `My Song/Music`), based on the uploaded video title. 

Replace those problem characters by underscores to avoid incorrect paths.
In above case, it was seeing it as a sub directory.