### PR TITLE
add support of custom youtube_dl implementation

### DIFF
--- a/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
+++ b/ytm/apis/YouTubeMusicDL/YouTubeMusicDL.py
@@ -23,6 +23,12 @@ import requests
 # )
 
 class BaseYouTubeMusicDL(object):
+    def __init__(self, youtube_downloader=None):
+        if not youtube_downloader:
+            import youtube_dl
+            youtube_downloader = youtube_dl.YoutubeDL
+        self._yt_dl = youtube_downloader
+
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}()>'
         
@@ -42,7 +48,6 @@ class BaseYouTubeMusicDL(object):
         import mutagen.id3
         import mutagen.mp4
         import mutagen.easymp4
-        import youtube_dl
 
         file_name_format = '%(title)s.%(ext)s'
 
@@ -73,7 +78,7 @@ class BaseYouTubeMusicDL(object):
                 }
             )
 
-        ytdl = youtube_dl.YoutubeDL \
+        ytdl = self._yt_dl \
         (
             params = \
             {


### PR DESCRIPTION
Allows to make use of custom but equivalent `youtube_dl` implementation transparently.

Multiple threads seem to indicate that https://github.com/ytdl-org/youtube-dl is slowly/unofficially deprecated, or at the very least not maintained. 

Instead, https://github.com/yt-dlp/yt-dlp  can be used directly as its successor. 
Initializing with `BaseYouTubeMusicDL(youtube_downloader=yt_dlp.YoutubeDL)` works properly and avoids some long lasting issues about slow download speeds, amongst other things.

Using this approach allows rapid switch to any package that implements the same methods as `YoutubeDL`, without needing to re-implement all the operations in `BaseYouTubeMusicDL._download`.
