### PR TITLE
fix for recent YTM updates

### DIFF
--- a/ytm/apis/AbstractYouTubeMusic/methods/artist.py
+++ b/ytm/apis/AbstractYouTubeMusic/methods/artist.py
@@ -17,10 +17,10 @@ def artist \
         (
             self:      object,
             artist_id: Union \
-            (
+            [
                 ArtistId,
                 ArtistBrowseId,
-            ),
+            ],
         ) -> dict:
     '''
     Fetch Artist data.

--- a/ytm/apis/BaseYouTubeMusic/methods/_get_page.py
+++ b/ytm/apis/BaseYouTubeMusic/methods/_get_page.py
@@ -57,7 +57,7 @@ def _get_page(self: object, *endpoints: str, params: dict = None) -> dict:
 
     config_match = re.search \
     (
-        pattern = r'ytcfg\.set\((?P<data>.*)\);',
+        pattern = r'ytcfg\.set\((?P<data>.*?)\);',
         string  = resp.text,
     )
 

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -348,6 +348,9 @@ def artist(data: dict) -> dict:
         if shelf_identifier in shelf_identifier_map:
             shelf_identifier = shelf_identifier_map[shelf_identifier]
 
+        if shelf_identifier == 'artist-made_playlists':
+            continue
+
         if shelf_identifier == 'singles_&_eps':
             continue  # already handled by songs and/or album-specific EPs
 

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -348,6 +348,9 @@ def artist(data: dict) -> dict:
         if shelf_identifier in shelf_identifier_map:
             shelf_identifier = shelf_identifier_map[shelf_identifier]
 
+        if shelf_identifier == 'singles_&_eps':
+            continue  # already handled by songs and/or album-specific EPs
+
         if shelf_identifier not in shelf_identifiers:
             raise Exception \
             (

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -362,7 +362,7 @@ def artist(data: dict) -> dict:
         if shelf_identifier not in shelf_identifiers:
             raise Exception \
             (
-                f'Unrecognised sheld identifier: {repr(shelf_identifier)}'
+                f'Unrecognised shelf identifier: {repr(shelf_identifier)}'
             )
 
         for shelf_item in shelf_contents:

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -145,6 +145,7 @@ def artist(data: dict) -> dict:
     {
         'featured_on':          'playlists',
         'fans_might_also_like': 'similar_artists',
+        'live_performances':    'videos',
     }
 
     for shelf_identifier in shelf_identifiers:
@@ -349,6 +350,10 @@ def artist(data: dict) -> dict:
             shelf_identifier = shelf_identifier_map[shelf_identifier]
 
         if shelf_identifier == 'artist-made_playlists':
+            continue
+        if shelf_identifier.startswith('playlists_by_'):
+            # identifier include the name of the artist for their custom lists
+            # omit the artist name altogether to avoid format failing matching it
             continue
 
         if shelf_identifier == 'singles_&_eps':

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -145,6 +145,8 @@ def artist(data: dict) -> dict:
     {
         'featured_on':          'playlists',
         'fans_might_also_like': 'similar_artists',
+        'playlists_by_volumes': 'playlists',
+        'live_performances':    'videos',
     }
 
     for shelf_identifier in shelf_identifiers:


### PR DESCRIPTION
- fix greedy regex when retrieving home `_get_page` causing extra javascript to be included
- fix extra artist sub-sections introduced by YTM depending on the artist's albums/singles
- fix artist parsing failing on their own custom playlists (`playlists_by_<artist-name>`)
- fix artist parsing failing on `live_performances` (they are structured like `videos` shelves)
- fix typing `Union` definition