### PR TITLE
fix equivalent mapping of `playlists_by_volumes` and `live_performances` shelves

### DIFF
--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -145,6 +145,8 @@ def artist(data: dict) -> dict:
     {
         'featured_on':          'playlists',
         'fans_might_also_like': 'similar_artists',
+        'playlists_by_volumes': 'playlists',
+        'live_performances':    'videos',
     }
 
     for shelf_identifier in shelf_identifiers:


### PR DESCRIPTION
New shelves have been recently introduced when parsing `artist(data)`:
- `playlists_by_volumes` 
- `live_performances`

Their contents are equivalently structured to `playlists` and `videos`, so they are mapped as it to keep parsing simple. 